### PR TITLE
Creates CI for some PR validation

### DIFF
--- a/.github/workflows/note.js.yml
+++ b/.github/workflows/note.js.yml
@@ -1,0 +1,32 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches-ignore: [ main ]
+  pull_request:
+    types:
+      - opened
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    # For the core sdk, simply running npm ci triggers a bunch of valiations to be run
+    - run: npm ci


### PR DESCRIPTION
If a PR is opened and targets the `main` branch, this creates a job to run `npm --clean-install` on the code in the PR, thus running all the validation that the openrpc tooling provides. If the job exits with a non-zero code, the job fails and the merge is not allowed.