### PR TITLE
fix: Uses new openrpc templates with fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@firebolt-js/openrpc": "^1.7.1-next.1",
+        "@firebolt-js/openrpc": "^1.7.1",
         "@firebolt-js/schemas": "^0.5.0-next.0",
         "ajv": "^6.12.6",
         "husky": "^8.0.0",
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@firebolt-js/openrpc": {
-      "version": "1.7.1-next.1",
-      "resolved": "https://registry.npmjs.org/@firebolt-js/openrpc/-/openrpc-1.7.1-next.1.tgz",
-      "integrity": "sha512-jOU3bwyugwHgTqSMONoXEYNaCQvb9/MPosxvtbawcxscoqDjlSEu5hM/hvRibjmP4zOOcF4peCYPFqaxHPG3EA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@firebolt-js/openrpc/-/openrpc-1.7.1.tgz",
+      "integrity": "sha512-4AbIUCABsqw8F19m/pwZh02MIJwLeV011pA+v+BaX9tr48pvtsjetSaBwJCqnDmTv/Nn+G4yTGzTeUsiB9NVUA==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.3.0",
@@ -7214,9 +7214,9 @@
       }
     },
     "@firebolt-js/openrpc": {
-      "version": "1.7.1-next.1",
-      "resolved": "https://registry.npmjs.org/@firebolt-js/openrpc/-/openrpc-1.7.1-next.1.tgz",
-      "integrity": "sha512-jOU3bwyugwHgTqSMONoXEYNaCQvb9/MPosxvtbawcxscoqDjlSEu5hM/hvRibjmP4zOOcF4peCYPFqaxHPG3EA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@firebolt-js/openrpc/-/openrpc-1.7.1.tgz",
+      "integrity": "sha512-4AbIUCABsqw8F19m/pwZh02MIJwLeV011pA+v+BaX9tr48pvtsjetSaBwJCqnDmTv/Nn+G4yTGzTeUsiB9NVUA==",
       "dev": true,
       "requires": {
         "ajv": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/rdkcentral/firebolt-manage-sdk#readme",
   "devDependencies": {
-    "@firebolt-js/openrpc": "^1.7.1-next.1",
+    "@firebolt-js/openrpc": "^1.7.1",
     "@firebolt-js/schemas": "^0.5.0-next.0",
     "ajv": "^6.12.6",
     "husky": "^8.0.0",


### PR DESCRIPTION
See https://github.com/rdkcentral/firebolt-openrpc/releases/tag/v1.7.1 for details.

This is kind of awkward having the fixes for bugs reported against the SDKs getting fixed in the tooling repo. And then where are the tests that validate those fixes to go?